### PR TITLE
Compile provider with static binaries

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,9 +8,9 @@ default: build
 release:
 	rm -fr bin
 	mkdir -p bin
-	GOARCH=amd64 GOOS=windows go build -o bin/terraform-provider-cloudfoundry_windows_amd64.exe
-	GOARCH=amd64 GOOS=linux go build -o bin/terraform-provider-cloudfoundry_linux_amd64
-	GOARCH=amd64 GOOS=darwin go build -o bin/terraform-provider-cloudfoundry_darwin_amd64
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -o bin/terraform-provider-cloudfoundry_windows_amd64.exe
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o bin/terraform-provider-cloudfoundry_linux_amd64
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=darwin go build -o bin/terraform-provider-cloudfoundry_darwin_amd64
 
 build: check
 	go install


### PR DESCRIPTION
There are issues running the provider in the terraform docker images, due to missing libraries on alpine linux. This fixes issues #136 where is may not be possible to run with mounted directories (eg GitHub actions). See https://github.com/terraform-providers/terraform-provider-helm/pull/111

I have tested the provider, after recompiling with `CGO_ENABLED=0`, inside the terraform docker image and it works. 

I thought it was best to keep the `CGO_ENABLED=0` inline with the release build commands, just to be as explicit as possible, plus it may slow down the compile time slightly and I felt it best to limit the usage to where it is required.