### PR TITLE
allow to specify service binding params as raw json string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ ENHANCEMENTS:
  * `cloudfoundry_app.route.default_route` deprecated in favor or `cloudfoundry_app.routes` array [#150](https://github.com/mevansam/terraform-provider-cf/pull/150) following cleaned up of blue/green unimplemented support. Thanks [@jcarrothers-sap](https://github.com/jcarrothers-sap).
  * Migration script to migrate from 0.9.8 to 0.9.9 syntax. [#165](https://github.com/mevansam/terraform-provider-cf/pull/165), [#171](https://github.com/mevansam/terraform-provider-cf/pull/171). Thanks [@janosbinder](https://github.com/janosbinder), [@lixilin2301](https://github.com/lixilin2301)
  * Added a flag support the recursive deletion of service bindings, service keys, and routes associated with the service instance. [#174](https://github.com/mevansam/terraform-provider-cf/pull/174). Thanks [@samedguener](https://github.com/samedguener), [@lixilin2301](https://github.com/lixilin2301)
-
+ * allow to specify service binding params as raw json string. [#200](https://github.com/mevansam/terraform-provider-cf/pull/200). Thanks [@abendt](https://github.com/abendt). 
 
 BUG FIXES:
   * changes to app health check required an app restart [#168](https://github.com/mevansam/terraform-provider-cf/pull/168). Thanks [@jcarrothers-sap](https://github.com/jcarrothers-sap)

--- a/cloudfoundry/resource_cf_app_test.go
+++ b/cloudfoundry/resource_cf_app_test.go
@@ -1321,6 +1321,73 @@ func TestAccApp_dockerApp(t *testing.T) {
 		})
 }
 
+func TestAccApp_getServiceBindingParams(t *testing.T) {
+	t.Run("params is used when present", func(t *testing.T) {
+		m := make(map[string]interface{})
+		p := make(map[string]interface{})
+		p["key"] = "value"
+
+		m["params"] = p
+		r, _ := getServiceBindingParams(m)
+
+		if r == nil {
+			t.Errorf("params should be non nil")
+		}
+
+		rr := *r
+
+		if v := rr["key"]; v != "value" {
+			t.Errorf("expected param to contain key => value, got %s", rr)
+		}
+	})
+
+	t.Run("params_json is used when present", func(t *testing.T) {
+		m := make(map[string]interface{})
+
+		m["params_json"] = `{"key": "value"}`
+
+		r, _ := getServiceBindingParams(m)
+
+		if r == nil {
+			t.Errorf("params should be non nil")
+		}
+
+		rr := *r
+
+		if v := rr["key"]; v != "value" {
+			t.Errorf("expected param to contain key => value, got %s", rr)
+		}
+	})
+
+	t.Run("params_json is ignored when present and empty", func(t *testing.T) {
+		m := make(map[string]interface{})
+
+		m["params_json"] = ""
+
+		r, _ := getServiceBindingParams(m)
+
+		if r != nil {
+			t.Errorf("params should be nil")
+		}
+	})
+
+	t.Run("params_json causes err if json is invalid", func(t *testing.T) {
+		m := make(map[string]interface{})
+
+		m["params_json"] = `invalidJson`
+
+		r, ok := getServiceBindingParams(m)
+
+		if r != nil {
+			t.Errorf("params should be nil")
+		}
+
+		if ok == nil {
+			t.Errorf("err should be non nil")
+		}
+	})
+}
+
 func testAccCheckAppExists(resApp string, validate func() error) resource.TestCheckFunc {
 
 	return func(s *terraform.State) (err error) {

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -86,6 +86,7 @@ One of the following arguments must be declared to locate application source or 
 
   - `service_instance` - (Required, String) The service instance GUID.
   - `params` - (Optional, Map) A list of key/value parameters used by the service broker to create the binding. Defaults to empty map.
+  - `params_json`- (Optional, String) service-specific configuration parameters in a valid JSON string. Defaults to empty string which is ignored.
 
 ~> **NOTE:** Modifying this argument will cause the application to be restaged.
 


### PR DESCRIPTION
this PR adds an extra parameter to the _cloudfoundry_app_. It allows to specify service binding params as raw json string.

https://github.com/mevansam/terraform-provider-cf/issues/199