### PR TITLE
added newRandomString function to generate long passwords

### DIFF
--- a/cloudfoundry/cfapi/session.go
+++ b/cloudfoundry/cfapi/session.go
@@ -352,3 +352,17 @@ func newUUID() (string, error) {
 	uuid[6] = uuid[6]&^0xf0 | 0x40
 	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
 }
+
+// newRandomString generates a random string of desired length
+func newRandomString(n int) (string, error) {
+    const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        bytes := make([]byte, n)
+        _, err := rand.Read(bytes)
+        if err != nil {
+            return "", err
+        }
+        for i, b := range bytes {
+            bytes[i] = letters[b%byte(len(letters))]
+        }
+        return string(bytes), nil
+}

--- a/cloudfoundry/cfapi/user_manager.go
+++ b/cloudfoundry/cfapi/user_manager.go
@@ -143,9 +143,13 @@ func (um *UserManager) loadGroups() (err error) {
 	if err != nil {
 		return err
 	}
+	password, err:= newRandomString(32)
+	if err != nil {
+		return err
+	}
 	userResource := UAAUser{
 		Username: username,
-		Password: "password",
+		Password: password,
 		Origin:   "uaa",
 		Emails:   []UAAUserEmail{{Value: "email@domain.com"}},
 	}


### PR DESCRIPTION
* Removed the hardcoded password as it was causing provider initialisation to fail when UAA password length policy is set.
* Added newRandomString method to generate new passwords with 32 characters

More details in https://github.com/cloudfoundry-community/terraform-provider-cf/issues/209