### PR TITLE
remove cf-hcl-migration from deploy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,26 +13,7 @@ builds:
     id: provider
     main: ./
     binary: terraform-provider-cloudfoundry
-  - goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-    env:
-      - CGO_ENABLED=0
-    id: cf-hcl-migration
-    main: ./cf-hcl-migration
-    binary: cf-hcl-migration
 archives:
-  - id: zip-archive-cf-hcl-migration
-    builds: [cf-hcl-migration]
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    format: zip
-  - id: binary-archive-cf-hcl-migration
-    builds: [cf-hcl-migration]
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    format: binary
   - id: zip-archive-provider
     builds: [provider]
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"

--- a/cf-hcl-migration/main.go
+++ b/cf-hcl-migration/main.go
@@ -1,3 +1,5 @@
+// This program was used for migrating tf files from version 0.9.9 to 0.10.0
+// this is no longer useful but i let the code because it can be useful some other day to know how to do
 package main
 
 import (


### PR DESCRIPTION
This is removing from deploy cf-hcl-migration which is no longer useful. But I let the code to keep knowledge on how to do 