### PR TITLE
don't get `allow_ssh` when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,10 @@ before_install:
   - curl -LSs "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.43.0" | tar -zvx -C .cf-cli/ -- cf
   - export PATH="$(pwd)/.cf-cli:$PATH"
   - export GO111MODULE=on
+  - GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
 jobs:
   include:
     - stage: testlint
-      install:
-        - GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
       script: travis_wait 360 scripts/build.sh
     - stage: testds
       script: travis_wait 360 scripts/build.sh

--- a/cloudfoundry/structures_app.go
+++ b/cloudfoundry/structures_app.go
@@ -1,25 +1,17 @@
 package cloudfoundry
 
 import (
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 	"encoding/json"
 	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-cloudfoundry/cloudfoundry/managers/appdeployers"
-	"time"
 )
 
 func ResourceDataToAppDeploy(d *schema.ResourceData) (appdeployers.AppDeploy, error) {
-	enableSSH := d.Get("enable_ssh").(bool)
-	if d.IsNewResource() {
-		// if user does not explicitly set allow_ssh
-		// it set allow ssh to true only during creation
-		if _, ok := d.GetOk("allow_ssh"); !ok {
-			enableSSH = true
-		}
-	}
-
 	app := ccv2.Application{
 		GUID:                    d.Id(),
 		Name:                    d.Get("name").(string),
@@ -29,7 +21,7 @@ func ResourceDataToAppDeploy(d *schema.ResourceData) (appdeployers.AppDeploy, er
 		StackGUID:               d.Get("stack").(string),
 		Buildpack:               StringToFilteredString(d.Get("buildpack").(string)),
 		Command:                 StringToFilteredString(d.Get("command").(string)),
-		EnableSSH:               BoolToNullBool(enableSSH),
+		EnableSSH:               BoolToNullBool(d.Get("enable_ssh").(bool)),
 		State:                   constant.ApplicationStarted,
 		DockerImage:             d.Get("docker_image").(string),
 		HealthCheckHTTPEndpoint: d.Get("health_check_http_endpoint").(string),


### PR DESCRIPTION
`cloudfoundry_app` resource does not have the `allow_ssh` parameter.
Therefore, `enable_ssh` was always true.

Signed-off-by: cappyzawa <cappyzawa@yahoo.ne.jp>