### PR TITLE
Fix app_resource service binding update

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -361,7 +361,7 @@ func resourceAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		for _, r := range remove {
-			bindings, _, err := session.ClientV2.GetRouteMappings(filterAppGuid(d.Id()), filterServiceInstanceGuid(r["service_instance"].(string)))
+			bindings, _, err := session.ClientV2.GetServiceBindings(filterAppGuid(d.Id()), filterServiceInstanceGuid(r["service_instance"].(string)))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Updates app_resource to retrieve list of existing service bindings instead of route mappings so they may be correctly removed.

Fixes #249