### PR TITLE
Fix v3 metadata handling

### DIFF
--- a/cloudfoundry/managers/bits/bitsmanager.go
+++ b/cloudfoundry/managers/bits/bitsmanager.go
@@ -51,8 +51,9 @@ func NewBitsManager(clientV2 *ccv2.Client, clientV3 *ccv3.Client, rawClient *raw
 // CopyApp - Copy one app to another by using only api
 func (m BitsManager) CopyApp(origAppGuid string, newAppGuid string) error {
 	path := fmt.Sprintf("/v2/apps/%s/copy_bits", newAppGuid)
-	data := bytes.NewReader([]byte(fmt.Sprintf(`{"source_app_guid":"%s"}`, origAppGuid)))
-	req, err := m.rawClient.NewRequest("POST", path, ioutil.NopCloser(data))
+	data := []byte(fmt.Sprintf(`{"source_app_guid":"%s"}`, origAppGuid))
+
+	req, err := m.rawClient.NewRequest("POST", path, data)
 	if err != nil {
 		return err
 	}
@@ -112,16 +113,17 @@ func (m BitsManager) UploadBuildpack(buildpackGUID string, bpPath string) error 
 		}
 		mpw.Close()
 	}()
-	request, err := m.rawClient.NewRequest("PUT", apiURL, nil)
+
+	req, err := m.rawClient.NewRequest("PUT", apiURL, nil)
 	if err != nil {
 		return err
 	}
 	contentType := fmt.Sprintf("multipart/form-data; boundary=%s", mpw.Boundary())
-	request.Header.Set("Content-Type", contentType)
-	request.ContentLength = m.predictPartBuildpack(baseName, fileSize, mpw.Boundary())
-	request.Body = r
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = m.predictPartBuildpack(baseName, fileSize, mpw.Boundary())
+	req.Body = r
 
-	_, err = m.rawClient.Do(request)
+	_, err = m.rawClient.Do(req)
 	if err != nil {
 		panic(err)
 	}
@@ -170,16 +172,16 @@ func (m BitsManager) UploadApp(appGUID string, path string) error {
 		}
 		mpw.Close()
 	}()
-	request, err := m.rawClient.NewRequest("PUT", apiURL, nil)
+	req, err := m.rawClient.NewRequest("PUT", apiURL, nil)
 	if err != nil {
 		return err
 	}
 	contentType := fmt.Sprintf("multipart/form-data; boundary=%s", mpw.Boundary())
-	request.Header.Set("Content-Type", contentType)
-	request.ContentLength = m.predictPartApp(fileSize, mpw.Boundary())
-	request.Body = r
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = m.predictPartApp(fileSize, mpw.Boundary())
+	req.Body = r
 
-	_, err = m.rawClient.Do(request)
+	_, err = m.rawClient.Do(req)
 	if err != nil {
 		panic(err)
 	}

--- a/cloudfoundry/resource_cf_service_broker.go
+++ b/cloudfoundry/resource_cf_service_broker.go
@@ -80,6 +80,8 @@ func resourceServiceBroker() *schema.Resource {
 				Default:     false,
 				Description: "Set to true if you want to see errors when getting service broker catalog",
 			},
+			labelsKey:      labelsSchema(),
+			annotationsKey: annotationsSchema(),
 		},
 	}
 }
@@ -107,6 +109,11 @@ func resourceServiceBrokerCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	d.SetId(sb.GUID)
+
+	err = metadataCreate(serviceBrokerMetadata, d, meta)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -138,7 +145,11 @@ func resourceServiceBrokerRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("username", sb.AuthUsername)
 	d.Set("space", sb.SpaceGUID)
 
-	return err
+	err = metadataRead(serviceBrokerMetadata, d, meta, false)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func resourceServiceBrokerUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -166,7 +177,11 @@ func resourceServiceBrokerUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	return err
+	err = metadataUpdate(serviceBrokerMetadata, d, meta)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func resourceServiceBrokerDelete(d *schema.ResourceData, meta interface{}) error {

--- a/docs/resources/service_broker.md
+++ b/docs/resources/service_broker.md
@@ -8,9 +8,9 @@ description: |-
 
 # cloudfoundry\_service\_broker
 
-Provides a Cloud Foundry resource for managing [service brokers](https://docs.cloudfoundry.org/services/) definitions. 
+Provides a Cloud Foundry resource for managing [service brokers](https://docs.cloudfoundry.org/services/) definitions.
 
-~> **NOTE:** To visibility of service plans provided by a registred service brijer, use the [cloudfoundry_service_plan_access](service_plan_access.html) resource. 
+~> **NOTE:** To visibility of service plans provided by a registred service brijer, use the [cloudfoundry_service_plan_access](service_plan_access.html) resource.
 ~> **NOTE:** This resource requires the provider to be authenticated with an account granted org manager permissions.
 ~> **NOTE:** If catalog is accessible to terraform broker will be automatically updated if catalog change from previous version in resource.
 
@@ -35,8 +35,12 @@ The following arguments are supported:
 * `url` - (Required) The URL to the service broker [API](https://docs.cloudfoundry.org/services/api.html)
 * `username` - (Required) The user name to use to authenticate against the service broker API calls
 * `password` - (Required) The password to authenticate against the service broker API calls
-* `space` - (Optional) The ID of the space to scope this broker to (registering the broker as [space-scoped](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker)). By default, registers [standard](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker) brokers 
+* `space` - (Optional) The ID of the space to scope this broker to (registering the broker as [space-scoped](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker)). By default, registers [standard](http://docs.cloudfoundry.org/services/managing-service-brokers.html#register-broker) brokers
 * `fail_when_catalog_not_accessible` - (Optional) Set to true if you want to see errors when getting service broker catalog (default behaviour is silently failed).
+* `labels` - (Optional, map string of string) Add labels as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+Works only on cloud foundry with api >= v3.71.
+* `annotations` - (Optional, map string of string) Add annotations as described [here](https://docs.cloudfoundry.org/adminguide/metadata.html#-view-metadata-for-an-object).
+Works only on cloud foundry with api >= v3.71.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR fixes the usage of cloudfoundry v3 metadata for existing objects and implements it for the service_broker resource.

Fixes details:
- use `PATCH` instead of `PUT` method
- prevent payload's readers of rawclient requests from being exhausted by debug output and retryable wrapper
- proper handle of metadata deletion

