### PR TITLE
Fallback check in case OrgManager has fewer permissions. Fixes #240

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
   - curl -LSs "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.43.0" | tar -zvx -C .cf-cli/ -- cf
   - export PATH="$(pwd)/.cf-cli:$PATH"
   - export GO111MODULE=on
-  - go install github.com/golangci/golangci-lint/cmd/golangci-lint
 jobs:
   include:
     - stage: testlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - curl -LSs "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.43.0" | tar -zvx -C .cf-cli/ -- cf
   - export PATH="$(pwd)/.cf-cli:$PATH"
   - export GO111MODULE=on
+  - go install github.com/golangci/golangci-lint/cmd/golangci-lint
 jobs:
   include:
     - stage: testlint

--- a/cloudfoundry/utils_clients.go
+++ b/cloudfoundry/utils_clients.go
@@ -80,9 +80,6 @@ func IsErrNotAuthorized(err error) bool {
 	if httpErr, ok := err.(ccerror.RawHTTPStatusError); ok && httpErr.StatusCode == 403 {
 		return true
 	}
-	if httpErr, ok := err.(ccerror.RawHTTPStatusError); ok && httpErr.StatusCode == 403 {
-		return true
-	}
 	if uaaErr, ok := err.(uaa.RawHTTPStatusError); ok && uaaErr.StatusCode == 403 {
 		return true
 	}
@@ -94,9 +91,6 @@ func IsErrNotFound(err error) bool {
 		return true
 	}
 	if _, ok := err.(ccerror.ResourceNotFoundError); ok {
-		return true
-	}
-	if httpErr, ok := err.(ccerror.RawHTTPStatusError); ok && httpErr.StatusCode == 404 {
 		return true
 	}
 	if uaaErr, ok := err.(uaa.RawHTTPStatusError); ok && uaaErr.StatusCode == 404 {

--- a/cloudfoundry/utils_clients.go
+++ b/cloudfoundry/utils_clients.go
@@ -73,6 +73,22 @@ func UsersToIDs(users []ccv2.User) []interface{} {
 	return ids
 }
 
+func IsErrNotAuthorized(err error) bool {
+	if _, ok := err.(ccerror.ForbiddenError); ok {
+		return true
+	}
+	if httpErr, ok := err.(ccerror.RawHTTPStatusError); ok && httpErr.StatusCode == 403 {
+		return true
+	}
+	if httpErr, ok := err.(ccerror.RawHTTPStatusError); ok && httpErr.StatusCode == 403 {
+		return true
+	}
+	if uaaErr, ok := err.(uaa.RawHTTPStatusError); ok && uaaErr.StatusCode == 403 {
+		return true
+	}
+	return false
+}
+
 func IsErrNotFound(err error) bool {
 	if httpErr, ok := err.(ccerror.RawHTTPStatusError); ok && httpErr.StatusCode == 404 {
 		return true

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,6 @@ github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1 h1:vTlpHKxJqykyKdW
 github.com/charlievieth/fs v0.0.0-20170613215519-7dc373669fa1/go.mod h1:sAoA1zHCH4FJPE2gne5iBiiVG66U7Nyp6JqlOo+FEyg=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudfoundry-community/cloudfoundry-cli v0.0.2-complete-api h1:gAym75FfG1DENlKO8FQLVGB2jZ+mxYUFUU82SzzmkIA=
-github.com/cloudfoundry-community/cloudfoundry-cli v0.0.2-complete-api/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
 github.com/cloudfoundry-community/cloudfoundry-cli v0.0.3-complete-api h1:wMOKglbBBxujUN2atoRlBdjjem198HLloe8FojdpKnA=
 github.com/cloudfoundry-community/cloudfoundry-cli v0.0.3-complete-api/go.mod h1:DigEBZwaNy/7RSrQpKuMeADXY5tFaWaieQX+UM8+0fA=
 github.com/cloudfoundry/bosh-cli v5.5.0+incompatible h1:P+hlG8D9xXIi75yqTpFrNBHR3oMWWMPNhj5AwSN2tOU=


### PR DESCRIPTION
It looks like newer version of the CF API limit
capabilities of OrgManagers. The call to get an 
overview of a user’s orgs could fail. In this case we 
can fall back to a (slower) check by looping through
all current users of the Org. This allows the operation
To proceed. This is crucial when the provider is 
operated by OrgManager accounts as it would otherwise
not allow them to create and populate spaces properly,
even though they can using the CF CLI.
The PR preserves the "fast path" for admin users.