### PR TITLE
Bump rack from 2.0.4 to 2.2.3 in /tests/cf-acceptance-tests/assets/service_broker

### DIFF
--- a/tests/cf-acceptance-tests/assets/service_broker/Gemfile.lock
+++ b/tests/cf-acceptance-tests/assets/service_broker/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     diff-lcs (1.3)
     json (2.1.0)
     mustermann (1.0.2)
-    rack (2.0.4)
+    rack (2.2.3)
     rack-protection (2.0.1)
       rack
     rack-test (0.8.3)


### PR DESCRIPTION
See https://github.com/cloudfoundry-community/terraform-provider-cf/pull/266