### PR TITLE
OrgManagers use of data.cloudfoundry_user

### DIFF
--- a/cloudfoundry/data_source_cf_user.go
+++ b/cloudfoundry/data_source_cf_user.go
@@ -22,9 +22,9 @@ func dataSourceUser() *schema.Resource {
 				Required: true,
 			},
 			"org_id": &schema.Schema{
-				Type: schema.TypeString,
+				Type:        schema.TypeString,
 				Description: "Optionally scope the lookup to organization",
-				Optional: true,
+				Optional:    true,
 			},
 		},
 	}


### PR DESCRIPTION
This patch uses the mechanism in PR #262 to support succesful lookups for OrgManagers. Typically they have a specific org as scope and with the optional `org_id` field it allows the data cloudfoundry_user resource to lookup the user UUID successfully. This negates the need to hardcode UUIDs in our scripts.

Note, the `org_id` is only used if the initial lookup fails so for existing users there is no change in behaviour.